### PR TITLE
[9]: Commands, e.g. !foo, are not replied when already in reply

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2233,8 +2233,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "twitch-irc"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37784b5551aef05babf0f948683b4a1daedf0135a1954607639491955206f2e3"
+source = "git+https://github.com/Retoon/twitch-irc-rs?branch=reply_parent_feature#86b6ec3c95ff6df3e129c2be375878e9ec1521d8"
 dependencies = [
  "async-trait",
  "bytes",

--- a/src/xddmod/Cargo.toml
+++ b/src/xddmod/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { workspace = true }
 tower = "0.4.13"
 twitch_api = { version = "0.7.0-rc.6", features = ["twitch_oauth2", "helix", "reqwest", "typed-builder"] }
 twitch_types = { version = "0.4.1", features = ["time"] }
-twitch-irc = { version = "5.0.0", features = ["with-serde", "refreshing-token-native-tls"] }
+twitch-irc = { git = "https://github.com/Retoon/twitch-irc-rs", "branch" = "reply_parent_feature", features = ["with-serde", "refreshing-token-native-tls"] }
 unicode-segmentation = "1.9.0"
 url = { version = "2.3.1", features = ["serde"] }
 webbrowser = "0.8.10"

--- a/src/xddmod/src/handlers/gamba_time/core.rs
+++ b/src/xddmod/src/handlers/gamba_time/core.rs
@@ -44,16 +44,7 @@ impl<'a> GambaTime<'a> {
 impl<'a> GambaTime<'a> {
     pub async fn handle(&self, server_message: &ServerMessage) {
         if let ServerMessage::Privmsg(message @ PrivmsgMessage { is_action: false, .. }) = server_message {
-            match Reply::matching(
-                self.handler(),
-                &message.channel_login,
-                &message.message_text,
-                None,
-                &self.db_pool,
-            )
-            .await
-            .as_slice()
-            {
+            match Reply::matching(self.handler(), message, &self.db_pool).await.as_slice() {
                 [reply] => {
                     let prediction_request = GetPredictionsRequest::builder()
                         .broadcaster_id(self.broadcaster_id.clone())

--- a/src/xddmod/src/handlers/gamba_time/core.rs
+++ b/src/xddmod/src/handlers/gamba_time/core.rs
@@ -48,6 +48,7 @@ impl<'a> GambaTime<'a> {
                 self.handler(),
                 &message.channel_login,
                 &message.message_text,
+                None,
                 &self.db_pool,
             )
             .await

--- a/src/xddmod/src/handlers/gg/core.rs
+++ b/src/xddmod/src/handlers/gg/core.rs
@@ -32,16 +32,7 @@ impl<'a> Gg<'a> {
 impl<'a> Gg<'a> {
     pub async fn handle(&self, server_message: &ServerMessage) {
         if let ServerMessage::Privmsg(message @ PrivmsgMessage { is_action: false, .. }) = server_message {
-            match Reply::matching(
-                self.handler(),
-                &message.channel_login,
-                &message.message_text,
-                None,
-                &self.db_pool,
-            )
-            .await
-            .as_slice()
-            {
+            match Reply::matching(self.handler(), message, &self.db_pool).await.as_slice() {
                 [reply @ Reply {
                     additional_inputs: Some(additional_inputs),
                     ..

--- a/src/xddmod/src/handlers/gg/core.rs
+++ b/src/xddmod/src/handlers/gg/core.rs
@@ -36,6 +36,7 @@ impl<'a> Gg<'a> {
                 self.handler(),
                 &message.channel_login,
                 &message.message_text,
+                None,
                 &self.db_pool,
             )
             .await

--- a/src/xddmod/src/handlers/npc/core.rs
+++ b/src/xddmod/src/handlers/npc/core.rs
@@ -28,6 +28,7 @@ impl<'a> Npc<'a> {
                 self.handler(),
                 &message.channel_login,
                 &message.message_text,
+                message.reply_parent.as_ref().map(|x| x.reply_parent_user.name.as_str()),
                 &self.db_pool,
             )
             .await

--- a/src/xddmod/src/handlers/npc/core.rs
+++ b/src/xddmod/src/handlers/npc/core.rs
@@ -24,16 +24,7 @@ impl<'a> Npc<'a> {
 impl<'a> Npc<'a> {
     pub async fn handle(&self, server_message: &ServerMessage) {
         if let ServerMessage::Privmsg(message @ PrivmsgMessage { is_action: false, .. }) = server_message {
-            match Reply::matching(
-                self.handler(),
-                &message.channel_login,
-                &message.message_text,
-                message.reply_parent.as_ref().map(|x| x.reply_parent_user.name.as_str()),
-                &self.db_pool,
-            )
-            .await
-            .as_slice()
-            {
+            match Reply::matching(self.handler(), message, &self.db_pool).await.as_slice() {
                 [reply] => {
                     // FIXME: poor man throttling
                     match poor_man_throttling::should_throttle(message, reply) {

--- a/src/xddmod/src/handlers/persistence.rs
+++ b/src/xddmod/src/handlers/persistence.rs
@@ -28,8 +28,13 @@ impl Reply {
         handler: Handler,
         channel: &str,
         message_text: &str,
+        reply_to: Option<&str>,
         executor: impl SqliteExecutor<'a>,
     ) -> Vec<Reply> {
+        let message_text = reply_to
+            .map(|x| message_text.trim_start_matches(&format!("@{}", x)).trim_start())
+            .unwrap_or(message_text);
+
         Self::all(handler, channel, executor)
             .await
             .unwrap()

--- a/src/xddmod/src/handlers/sniffa/core.rs
+++ b/src/xddmod/src/handlers/sniffa/core.rs
@@ -36,6 +36,7 @@ impl<'a> Sniffa<'a> {
                 self.handler(),
                 &message.channel_login,
                 &message.message_text,
+                None,
                 &self.db_pool,
             )
             .await

--- a/src/xddmod/src/handlers/sniffa/core.rs
+++ b/src/xddmod/src/handlers/sniffa/core.rs
@@ -32,16 +32,7 @@ impl<'a> Sniffa<'a> {
 impl<'a> Sniffa<'a> {
     pub async fn handle(&self, server_message: &ServerMessage) {
         if let ServerMessage::Privmsg(message @ PrivmsgMessage { is_action: false, .. }) = server_message {
-            match Reply::matching(
-                self.handler(),
-                &message.channel_login,
-                &message.message_text,
-                None,
-                &self.db_pool,
-            )
-            .await
-            .as_slice()
-            {
+            match Reply::matching(self.handler(), message, &self.db_pool).await.as_slice() {
                 [reply @ Reply {
                     additional_inputs: Some(additional_inputs),
                     ..

--- a/src/xddmod/src/lib.rs
+++ b/src/xddmod/src/lib.rs
@@ -2,7 +2,7 @@ pub mod apis;
 pub mod app_config;
 pub mod auth;
 pub mod handlers;
-pub mod templates_env;
 pub mod poor_man_throttling;
+pub mod templates_env;
 
 pub use chrono_tz::Tz;


### PR DESCRIPTION
Fix the bug that didn't permit to use registered cmds, e.g. `!time`, in Twitch threads.

The resolution was done by:
- pointing to [this open PR](https://github.com/robotty/twitch-irc-rs/pull/189) to get `ReplyParent` in `PrivmsgMessage`
- leverage `ReplyParent` to properly "clean" the message text of the `PrivmsgMessage` & making it match the `replies`