### PR TITLE
[87]: Fix `RipBozo` to avoid counting chatters names as unpermitted chars

### DIFF
--- a/src/xddmod/src/handlers/rip_bozo/core.rs
+++ b/src/xddmod/src/handlers/rip_bozo/core.rs
@@ -15,6 +15,11 @@ use unicode_segmentation::UnicodeSegmentation;
 use crate::apis::twitch;
 use crate::handlers::persistence::Handler;
 
+lazy_static! {
+    static ref EMOJI_REGEX: Regex = Regex::new(r"\p{Emoji}").unwrap();
+    static ref MENTION_REGEX: Regex = Regex::new(r"(@(\w+))").unwrap();
+}
+
 pub struct RipBozo<'a> {
     pub broadcaster_id: UserId,
     pub token: UserToken,
@@ -85,11 +90,6 @@ impl<'a> RipBozo<'a> {
             }
         }
     }
-}
-
-lazy_static! {
-    static ref EMOJI_REGEX: Regex = Regex::new(r"\p{Emoji}").unwrap();
-    static ref MENTION_REGEX: Regex = Regex::new(r"(@(\w+))").unwrap();
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/xddmod/src/main.rs
+++ b/src/xddmod/src/main.rs
@@ -18,6 +18,7 @@ async fn main() {
     let (mut incoming_messages, irc_client, user_token) = auth::authenticate(app_config.clone()).await;
 
     let helix_client: HelixClient<'static, reqwest::Client> = HelixClient::default();
+
     let broadcaster = helix_client
         .get_user_from_login(&channel, &user_token)
         .await


### PR DESCRIPTION
The [API](https://docs.rs/twitch_api/0.7.0-rc.6/twitch_api/struct.HelixClient.html#method.get_user_from_login) mentioned inside the related issue https://github.com/fusillicode/xddmod/issues/87 doesn't answer to the question: is the chatter in chat?
Given the lack of an "out of the box" API to answer this question I fall back to a more dumb solution.

Exploiter of the dumb solution will be perma! 😤