### PR TITLE
[139]: Fix `TheGrind` wrong lp with new opgg JSON API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dankcontent"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "fake",
+ "lazy_static",
+ "minijinja",
+ "pomsky-macro",
+ "rand",
+ "regex",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tokio",
+ "xddmod",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1612,30 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "pomsky"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6807866ef2d693e9770774e9443d64aa98e4da3de805130b9387d0d05e00f0e"
+dependencies = [
+ "pomsky-syntax",
+]
+
+[[package]]
+name = "pomsky-macro"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec61110bbb75607cd71ca75d2ccfd216658dc4f942ac92ec5a7db2984e3871b"
+dependencies = [
+ "pomsky",
+]
+
+[[package]]
+name = "pomsky-syntax"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034aa21218419dc25ae3aa753bd8080bbe1a4c14f217f4d23cd501c911f7889d"
 
 [[package]]
 name = "ppv-lite86"

--- a/src/xddmod/src/apis/op_gg.rs
+++ b/src/xddmod/src/apis/op_gg.rs
@@ -8,7 +8,8 @@ pub mod games;
 pub mod spectate;
 pub mod summoners;
 
-pub const OP_GG_API: &str = "https://op.gg/api/v1.0/internal/bypass";
+pub const OP_GG_INTERNAL_API: &str = "https://op.gg/api/v1.0/internal/bypass";
+pub const OP_GG_NEXT_API: &str = "https://op.gg/_next/data/4lhOLzvEROMwUXJXnC8xJ/en_US";
 
 #[derive(Clone, Copy, Debug, Dummy, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/src/xddmod/src/apis/op_gg/games.rs
+++ b/src/xddmod/src/apis/op_gg/games.rs
@@ -11,7 +11,7 @@ use crate::apis::op_gg::summoners::Summoner;
 use crate::apis::op_gg::Region;
 use crate::apis::op_gg::TeamKey;
 use crate::apis::op_gg::TierInfo;
-use crate::apis::op_gg::OP_GG_API;
+use crate::apis::op_gg::OP_GG_INTERNAL_API;
 
 pub async fn get_last_game(region: Region, summoner_id: &str) -> anyhow::Result<Option<Game>> {
     let games = get_games(region, summoner_id, None, None, Some(1)).await?;
@@ -26,7 +26,10 @@ async fn get_games(
     maybe_to: Option<DateTime<Utc>>,
     maybe_limit: Option<i32>,
 ) -> anyhow::Result<Games> {
-    let mut url = Url::parse(&format!("{}/games/{}/summoners/{}", OP_GG_API, region, summoner_id))?;
+    let mut url = Url::parse(&format!(
+        "{}/games/{}/summoners/{}",
+        OP_GG_INTERNAL_API, region, summoner_id
+    ))?;
 
     fn build_query(maybe_to: Option<DateTime<Utc>>, maybe_limit: Option<i32>) -> String {
         let mut query = "game_type=total".to_owned();

--- a/src/xddmod/src/apis/op_gg/spectate.rs
+++ b/src/xddmod/src/apis/op_gg/spectate.rs
@@ -11,10 +11,10 @@ use crate::apis::ddragon::ChampionKey;
 use crate::apis::op_gg::Region;
 use crate::apis::op_gg::TeamKey;
 use crate::apis::op_gg::TierInfo;
-use crate::apis::op_gg::OP_GG_API;
+use crate::apis::op_gg::OP_GG_INTERNAL_API;
 
 pub async fn get_spectate_status(region: Region, summoner_id: &str) -> anyhow::Result<SpectateStatus> {
-    let url = Url::parse(&format!("{}/spectates/{}/{}", OP_GG_API, region, summoner_id))?;
+    let url = Url::parse(&format!("{}/spectates/{}/{}", OP_GG_INTERNAL_API, region, summoner_id))?;
     let spectate_status = reqwest::get(url.clone()).await?.json().await?;
 
     Ok(spectate_status)

--- a/src/xddmod/src/apis/op_gg/summoners.rs
+++ b/src/xddmod/src/apis/op_gg/summoners.rs
@@ -47,5 +47,29 @@ pub struct Summoner {
     pub profile_image_url: String,
     pub level: i64,
     pub updated_at: DateTime<Utc>,
-    pub solo_tier_info: Option<TierInfo>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Dummy)]
+pub struct SummonerJson {
+    #[serde(flatten)]
+    pub common: CommonSummoner,
+    pub lp_histories: Vec<LpHistory>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Dummy)]
+pub struct LpHistory {
+    pub elo_point: i64,
+    pub tier_info: TierInfo,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Dummy)]
+struct SummonerJsonResponse {
+    #[serde(rename(deserialize = "pageProps"))]
+    page_props: PageProps,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Dummy)]
+struct PageProps {
+    data: SummonerJson,
 }

--- a/src/xddmod/src/apis/op_gg/summoners.rs
+++ b/src/xddmod/src/apis/op_gg/summoners.rs
@@ -8,7 +8,8 @@ use serde::Serialize;
 
 use crate::apis::op_gg::Region;
 use crate::apis::op_gg::TierInfo;
-use crate::apis::op_gg::OP_GG_API;
+use crate::apis::op_gg::OP_GG_INTERNAL_API;
+use crate::apis::op_gg::OP_GG_NEXT_API;
 
 pub async fn get_summoner(region: Region, summoner_name: &str) -> anyhow::Result<Summoner> {
     match &get_summoners(region, summoner_name).await?.data[..] {

--- a/src/xddmod/src/apis/op_gg/summoners.rs
+++ b/src/xddmod/src/apis/op_gg/summoners.rs
@@ -24,8 +24,22 @@ pub async fn get_summoner(region: Region, summoner_name: &str) -> anyhow::Result
     }
 }
 
+pub async fn get_summoner_json(region: Region, summoner_name: &str) -> anyhow::Result<SummonerJson> {
+    let url = Url::parse(&format!(
+        "{}/summoners/{}/{}.json",
+        OP_GG_NEXT_API, region, summoner_name
+    ))?;
+
+    Ok(reqwest::get(url)
+        .await?
+        .json::<SummonerJsonResponse>()
+        .await?
+        .page_props
+        .data)
+}
+
 async fn get_summoners(region: Region, summoner_name: &str) -> anyhow::Result<Summoners> {
-    let mut url = Url::parse(&format!("{}/summoners/{}/autocomplete", OP_GG_API, region))?;
+    let mut url = Url::parse(&format!("{}/summoners/{}/autocomplete", OP_GG_INTERNAL_API, region))?;
     url.set_query(Some(&format!("keyword={}", summoner_name)));
 
     Ok(reqwest::get(url).await?.json().await?)
@@ -38,6 +52,13 @@ pub struct Summoners {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Dummy)]
 pub struct Summoner {
+    #[serde(flatten)]
+    pub common: CommonSummoner,
+    pub solo_tier_info: Option<TierInfo>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Dummy)]
+pub struct CommonSummoner {
     pub id: i64,
     pub summoner_id: String,
     pub acct_id: String,

--- a/src/xddmod/src/handlers/gg/core.rs
+++ b/src/xddmod/src/handlers/gg/core.rs
@@ -60,7 +60,7 @@ impl<'a> Gg<'a> {
                             .unwrap();
 
                             if let Some(game) =
-                                op_gg::games::get_last_game(additional_inputs.region, &summoner.summoner_id)
+                                op_gg::games::get_last_game(additional_inputs.region, &summoner.common.summoner_id)
                                     .await
                                     .unwrap()
                             {

--- a/src/xddmod/src/handlers/sniffa/core.rs
+++ b/src/xddmod/src/handlers/sniffa/core.rs
@@ -60,9 +60,10 @@ impl<'a> Sniffa<'a> {
                             .await
                             .unwrap();
 
-                            let spectate_status = get_spectate_status(additional_inputs.region, &summoner.summoner_id)
-                                .await
-                                .unwrap();
+                            let spectate_status =
+                                get_spectate_status(additional_inputs.region, &summoner.common.summoner_id)
+                                    .await
+                                    .unwrap();
 
                             let template_inputs = TemplateInputs {
                                 summoner,


### PR DESCRIPTION
Instead of getting lp from the as suggested by this PR related issue https://github.com/fusillicode/xddmod/issues/139 a new opgg JSON API was leveraged.

Common `Summoner` fields has been extracted in a new `CommonSummoner` struct.